### PR TITLE
Add simple web front end for Graham screens

### DIFF
--- a/Cad.py
+++ b/Cad.py
@@ -1,12 +1,12 @@
 import pandas as pd
 import yfinance as yf
 
-def main():
-    # 1) Fetch S&P/TSX 60 Index constituents from Wikipedia
+
+def compute_tsx60_graham_screen():
+    """Return full and passing Graham screen DataFrames for the S&P/TSX 60."""
     wiki_url = "https://en.wikipedia.org/wiki/S%26P/TSX_60"
     tables = pd.read_html(wiki_url, header=0)
 
-    # 2) Identify the table with 'Symbol' and 'Company' columns
     tsx_df = None
     for t in tables:
         cols = [str(c).lower() for c in t.columns]
@@ -16,8 +16,6 @@ def main():
     if tsx_df is None:
         raise ValueError("Could not find TSX 60 constituents table with 'Symbol' & 'Company' columns")
 
-    # 3) Standardize column names and prepare tickers
-    # Some pages label symbol column as 'Ticker'; handle both
     symbol_col = next(c for c in tsx_df.columns if str(c).lower() in ('symbol', 'ticker'))
     company_col = next(c for c in tsx_df.columns if 'company' in str(c).lower())
     sector_col = next((c for c in tsx_df.columns if 'gics' in str(c).lower() or 'sector' in str(c).lower()), None)
@@ -27,9 +25,7 @@ def main():
     tsx_df['Ticker'] = tsx_df['Ticker'].astype(str).str.strip() + '.TO'
 
     tickers = tsx_df['Ticker'].tolist()
-    print(f"Total TSX 60 tickers: {len(tickers)}")
 
-    # 4) Fetch P/E, P/B and compute Graham product (only if P/B > 0)
     data = []
     for symbol in tickers:
         try:
@@ -58,24 +54,23 @@ def main():
             entry['Sector'] = tsx_df.loc[tsx_df['Ticker'] == symbol, 'Sector'].values[0]
         data.append(entry)
 
-    # 5) Build DataFrame
     df = pd.DataFrame(data).set_index('Ticker')
-
-    # 6) Remove entries with non-positive P/B
     df = df[df['P/B (mrq)'] > 0]
+    df_pass = df[df['Passes ≤22.5'] == True]
+    return df, df_pass
 
-    # 7) Display all rows
+
+def main():
+    df, df_pass = compute_tsx60_graham_screen()
+
     pd.set_option('display.max_rows', len(df))
     print("\nAll TSX 60 companies with P/B > 0:\n", df)
-
-    # 8) Filter and display only passing companies
-    df_pass = df[df['Passes ≤22.5'] == True]
     print("\nCompanies passing Graham's screen (P/E×P/B ≤ 22.5):\n", df_pass)
     print(f"\nTotal passing companies: {len(df_pass)}")
 
-    # 9) Export results to CSV
     df.to_csv('tsx60_graham_screen.csv')
     df_pass.to_csv('tsx60_graham_screen_pass.csv')
+
 
 if __name__ == '__main__':
     main()

--- a/PE.py
+++ b/PE.py
@@ -1,30 +1,22 @@
 import pandas as pd
 import yfinance as yf
 
-def main():
-    # 1) Fetch S&P 500 table
+
+def compute_sp500_graham_screen():
+    """Return full and passing Graham screen DataFrames for the S&P 500."""
     wiki_url = "https://en.wikipedia.org/wiki/List_of_S%26P_500_companies"
     sp500_df = pd.read_html(wiki_url, header=0)[0]
-
-    # 2) Collapse any remaining classes by company base name
     sp500_df['Base'] = sp500_df['Security'].str.replace(r"\s+Class.*$", "", regex=True)
     sp500_df = sp500_df.drop_duplicates(subset='Base', keep='first')
-
-    # 3) Remove share-class tickers by symbol punctuation
     sp500_df = sp500_df[~sp500_df['Symbol'].str.contains(r"[\.-]")]
-
-    # 4) Extract cleaned ticker list
     tickers = sp500_df['Symbol'].tolist()
-    print(f"Total tickers after cleaning: {len(tickers)}")  # should print 500
 
-    # 5) Fetch P/E, P/B and compute Graham product (only if P/B > 0)
     data = []
     for symbol in tickers:
         try:
             info = yf.Ticker(symbol).info
             pe = info.get('trailingPE')
             pb = info.get('priceToBook')
-            # Only compute and flag if pb > 0
             if pe is not None and pb is not None and pb > 0:
                 product = pe * pb
                 passes = (product <= 22.5)
@@ -43,24 +35,23 @@ def main():
             'Passes ≤22.5': passes
         })
 
-    # 6) Build DataFrame
     df = pd.DataFrame(data).set_index('Ticker')
-
-    # 7) Remove entries with non-positive P/B
     df = df[df['P/B (mrq)'] > 0]
+    df_pass = df[df['Passes ≤22.5'] == True]
+    return df, df_pass
 
-    # 8) Display all rows
+
+def main():
+    df, df_pass = compute_sp500_graham_screen()
+
     pd.set_option('display.max_rows', len(df))
     print("\nAll companies with P/B > 0:\n", df)
-
-    # 9) Filter and display only passing companies
-    df_pass = df[df['Passes ≤22.5'] == True]
     print("\nCompanies passing Graham's screen (P/E×P/B ≤ 22.5):\n", df_pass)
     print(f"\nTotal passing companies: {len(df_pass)}")
 
-    # 10) Export full and filtered lists to CSV
     df.to_csv('sp500_graham_screen.csv')
     df_pass.to_csv('sp500_graham_screen_pass.csv')
+
 
 if __name__ == '__main__':
     main()

--- a/app.py
+++ b/app.py
@@ -1,0 +1,37 @@
+from flask import Flask, render_template
+
+from PE import compute_sp500_graham_screen
+from Cad import compute_tsx60_graham_screen
+
+app = Flask(__name__)
+
+
+@app.route('/')
+def index():
+    return render_template('index.html')
+
+
+@app.route('/sp500')
+def sp500():
+    df, df_pass = compute_sp500_graham_screen()
+    return render_template(
+        'results.html',
+        title='S&P 500 Graham Screen',
+        full=df.to_html(classes='data'),
+        passed=df_pass.to_html(classes='data')
+    )
+
+
+@app.route('/tsx60')
+def tsx60():
+    df, df_pass = compute_tsx60_graham_screen()
+    return render_template(
+        'results.html',
+        title='S&P/TSX 60 Graham Screen',
+        full=df.to_html(classes='data'),
+        passed=df_pass.to_html(classes='data')
+    )
+
+
+if __name__ == '__main__':
+    app.run(debug=True)

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,0 +1,19 @@
+<!doctype html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <title>Intelligent Investor Screens</title>
+    <style>
+        body { font-family: Arial, sans-serif; margin: 2em; }
+        a.button { padding: 0.5em 1em; background: #007bff; color: #fff; text-decoration: none; border-radius: 4px; margin-right: 1em; }
+    </style>
+</head>
+<body>
+    <h1>Intelligent Investor Graham Screens</h1>
+    <p>Select a market to analyze:</p>
+    <p>
+        <a href="/sp500" class="button">S&amp;P 500</a>
+        <a href="/tsx60" class="button">S&amp;P/TSX 60</a>
+    </p>
+</body>
+</html>

--- a/templates/results.html
+++ b/templates/results.html
@@ -1,0 +1,21 @@
+<!doctype html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <title>{{ title }}</title>
+    <style>
+        body { font-family: Arial, sans-serif; margin: 2em; }
+        table.data { border-collapse: collapse; width: 100%; margin-bottom: 2em; }
+        table.data th, table.data td { border: 1px solid #ccc; padding: 0.3em; text-align: right; }
+        table.data th { background: #f8f8f8; }
+    </style>
+</head>
+<body>
+    <h1>{{ title }}</h1>
+    <h2>All Companies with P/B &gt; 0</h2>
+    {{ full|safe }}
+    <h2>Companies Passing Graham Screen</h2>
+    {{ passed|safe }}
+    <p><a href="/">Back</a></p>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- refactor data scripts to expose functions that return DataFrames
- add Flask app to run Graham screens for S&P500 and TSX60
- basic HTML templates for navigation and results

## Testing
- `python3 -m py_compile PE.py Cad.py app.py`
- `python3 app.py` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_684900fbc5b883298e609c4836b94656